### PR TITLE
Feature/JSX automatic runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ function flattenAll(input, result = []) {
     return result
 }
 
-export default (type, props, ...children) =>
-    typeof type === 'function'
+export default (type, { children: children1, ...props }, ...children2) => {
+    const children = [].concat(children1).concat(children2);
+    return typeof type === 'function'
         ? type(props, flattenAll(children))
         : h(
               type,
@@ -20,3 +21,4 @@ export default (type, props, ...children) =>
                       : child
               )
           )
+}

--- a/index.js
+++ b/index.js
@@ -8,9 +8,8 @@ function flattenAll(input, result = []) {
     return result
 }
 
-export default (type, { children: children1, ...props }, ...children2) => {
-    const children = [].concat(children1).concat(children2);
-    return typeof type === 'function'
+export default (type, props, ...children) =>
+    typeof type === 'function'
         ? type(props, flattenAll(children))
         : h(
               type,
@@ -21,4 +20,3 @@ export default (type, { children: children1, ...props }, ...children2) => {
                       : child
               )
           )
-}

--- a/jsx-runtime/index.js
+++ b/jsx-runtime/index.js
@@ -1,3 +1,23 @@
-import h from '..'
+import { h, text } from "hyperapp"
 
-export { h as jsx, h as jsxs }
+const childNode = (child) => typeof child === "string" || typeof child === "number" ? text(child) : child;
+
+export const jsx = (tag, { children, ...props }, key) =>
+  typeof tag === "function"
+    ? tag({ ...props, key }, children)
+    : h(
+        tag,
+        { ...props, key },
+        childNode(children)
+      )
+    
+
+export const jsxs = (tag, { children, ...props }, key) =>
+  typeof tag === "function"
+    ? tag({ ...props, key }, children)
+    : h(
+        tag,
+        { ...props, key },
+        children.map(childNode)
+      )
+

--- a/jsx-runtime/index.js
+++ b/jsx-runtime/index.js
@@ -1,0 +1,3 @@
+import h from '..'
+
+export { h as jsx, h as jsxs }


### PR DESCRIPTION
Adds support for the new jsx automatic runtime via the added `jsx-runtime/index.js` file.

If you notice, in the first commit, I tried supporting it with the existing function, but that doesn't work very well as the new jsx runtime passes keys as the third argument (on top of children via props). I created new functions instead. It's also more performant this way as it avoid doing unnecessary Array.concats / pushes / conditional stuff for child nodes.


## Usage:

With `jsconfig.json` or `tsconfig.json`:

```json
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxImportSource": "hyperapp-jsx-pragma"
  }
}
```

If using babel `@babel/preset-react` >v7.9.0 or `@babel/plugin-transform-react-jsx` >v7.9.0: 

```json
{
  "presets": [
    [
      "@babel/preset-react",
      {
        "runtime": "automatic",
        "importSource": "hyperapp-jsx-pragma"
      }
    ]
  ]
}
```

Look [here](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx) for more info.

## Note

As I left the index.js file untouched, the "classic" runtime will still work just as well as before (no breaking changes)